### PR TITLE
Latest Minestom Support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     val minestom = "net.minestom:minestom:2025.12.20-1.21.11"
 
     compileOnly(minestom)
+    compileOnly("it.unimi.dsi:fastutil:8.5.18")
 
     testImplementation(minestom)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ repositories {
 dependencies {
     api("org.jetbrains:annotations:24.0.1")
 
-    val minestom = "net.minestom:minestom:2025.07.04-1.21.5"
+    val minestom = "net.minestom:minestom:2025.12.20-1.21.11"
 
     compileOnly(minestom)
 
@@ -33,7 +33,7 @@ tasks.test {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(25))
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Aug 17 23:49:03 CDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/net/goldenstack/loot/LootFunction.java
+++ b/src/main/java/net/goldenstack/loot/LootFunction.java
@@ -6,11 +6,15 @@ import net.goldenstack.loot.util.nbt.NBTReference;
 import net.goldenstack.loot.util.nbt.NBTUtils;
 import net.goldenstack.loot.util.predicate.ItemPredicate;
 import net.kyori.adventure.key.Key;
-import net.kyori.adventure.nbt.*;
+import net.kyori.adventure.nbt.BinaryTag;
+import net.kyori.adventure.nbt.CompoundBinaryTag;
+import net.kyori.adventure.nbt.ListBinaryTag;
+import net.kyori.adventure.nbt.TagStringIO;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.util.RGBLike;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.ServerFlag;
+import net.minestom.server.adventure.MinestomAdventure;
 import net.minestom.server.codec.Codec;
 import net.minestom.server.codec.Result;
 import net.minestom.server.codec.StructCodec;
@@ -30,6 +34,7 @@ import net.minestom.server.item.book.FilteredText;
 import net.minestom.server.item.component.*;
 import net.minestom.server.item.enchant.Enchantment;
 import net.minestom.server.item.instrument.Instrument;
+import net.minestom.server.network.player.ResolvableProfile;
 import net.minestom.server.potion.PotionEffect;
 import net.minestom.server.potion.PotionType;
 import net.minestom.server.registry.DynamicRegistry;
@@ -614,7 +619,7 @@ public interface LootFunction {
             PlayerSkin skin = player.getSkin();
             if (skin == null) return input;
 
-            return input.with(DataComponents.PROFILE, new HeadProfile(skin));
+            return input.with(DataComponents.PROFILE, new ResolvableProfile(skin));
         }
 
         @Override
@@ -957,7 +962,7 @@ public interface LootFunction {
                     } catch (IOException e) {
                         throw new RuntimeException(e);
                     }
-                }, TagStringIOExt::writeTag), SetCustomData::tag,
+                }, MinestomAdventure.tagStringIO()::asString), SetCustomData::tag,
                 SetCustomData::new
         );
 

--- a/src/main/java/net/goldenstack/loot/util/nbt/NBTPath.java
+++ b/src/main/java/net/goldenstack/loot/util/nbt/NBTPath.java
@@ -1,7 +1,11 @@
 package net.goldenstack.loot.util.nbt;
 
 import it.unimi.dsi.fastutil.ints.IntSet;
-import net.kyori.adventure.nbt.*;
+import net.kyori.adventure.nbt.BinaryTag;
+import net.kyori.adventure.nbt.CompoundBinaryTag;
+import net.kyori.adventure.nbt.ListBinaryTag;
+import net.kyori.adventure.nbt.TagStringIO;
+import net.minestom.server.adventure.MinestomAdventure;
 import net.minestom.server.codec.Codec;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -469,7 +473,12 @@ class Parser {
 
         String dump = builder.toString();
 
-        Map.Entry<BinaryTag, String> entry = TagStringIOExt.readTagEmbedded(dump);
+        Map.Entry<BinaryTag, String> entry;
+
+        StringBuilder remainder = new StringBuilder();
+        BinaryTag tag = MinestomAdventure.tagStringIO().asTag(dump, remainder);
+
+        entry = Map.entry(tag, remainder.toString());
 
         reader.skip(-count + entry.getValue().length());
         return entry.getKey();


### PR DESCRIPTION
This PR adds support for Minestom 2025.12.20-1.21.11

### Summary of changes

- Updated Minestom dependency to 2025.12.20-1.21.11
- Upgraded Gradle wrapper to 9.2.1
- Bumped Java toolchain to Java 25
- Re-added fastutil as an explicit dependency, as it is no longer transitively provided
- Migrated deprecated / removed Minestom APIs:
  - Replaced HeadProfile with ResolvableProfile
  - Updated NBT parsing and serialization to use MinestomAdventure.tagStringIO()